### PR TITLE
Update to allow for neo4j v8

### DIFF
--- a/carrierwave-neo4j.gemspec
+++ b/carrierwave-neo4j.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport", ">= 3.0" )
   s.add_dependency("neo4j", ">= 3.0.0")
-  s.add_dependency("carrierwave", "~> 0.5")
+  s.add_dependency("carrierwave", ">= 0.5")
   s.add_development_dependency("rspec", "~> 2.0")
 end

--- a/lib/carrierwave/neo4j.rb
+++ b/lib/carrierwave/neo4j.rb
@@ -46,11 +46,6 @@ module CarrierWave
           write_uploader(_mounter(:#{column}).serialization_column, nil)
         end
 
-        def _mounter(column)
-          @_mounters ||= {}
-          @_mounters[column] ||= CarrierWave::Mount::Mounter.new(self, column)
-        end
-
         def read_uploader(name)
           send(:attribute, name.to_s)
         end


### PR DESCRIPTION
To allow usage with neo4j version 8 we'll need a more recent version of
`carrierwave` to resolve the `activesupport` dependency.